### PR TITLE
Role & org-aware auth/context, RLS notes, and French UI with scoped r…

### DIFF
--- a/web/docs/rls-v0.3.2-notes.sql
+++ b/web/docs/rls-v0.3.2-notes.sql
@@ -1,0 +1,43 @@
+-- Suggested RLS additions for V0.3.2 role-based scoping.
+-- Keep using anon/authenticated client keys (no service role in frontend).
+
+-- Organizations: facilitators can read all, others only their own organization.
+drop policy if exists "organizations_read_scoped" on public.organizations;
+create policy "organizations_read_scoped"
+on public.organizations
+for select
+using (
+  exists (
+    select 1
+    from public.memberships m
+    where m.user_id = auth.uid()
+      and (
+        m.role in ('facilitator', 'admin')
+        or m.organization_id = organizations.id
+      )
+  )
+);
+
+-- Projects: facilitators can read all, others only projects tied to their organization.
+drop policy if exists "projects_read_scoped" on public.projects;
+create policy "projects_read_scoped"
+on public.projects
+for select
+using (
+  exists (
+    select 1
+    from public.memberships m
+    where m.user_id = auth.uid()
+      and (
+        m.role in ('facilitator', 'admin')
+        or m.organization_id = projects.organization_id
+      )
+  )
+);
+
+-- Memberships: users can read their own memberships.
+drop policy if exists "memberships_read_own" on public.memberships;
+create policy "memberships_read_own"
+on public.memberships
+for select
+using (user_id = auth.uid());

--- a/web/src/auth.js
+++ b/web/src/auth.js
@@ -1,5 +1,21 @@
 import { supabase } from './supabase.js';
 
+const roleAliases = {
+  student: 'student',
+  eleve: 'student',
+  'élève': 'student',
+  referent: 'referent',
+  'référent': 'referent',
+  facilitator: 'facilitator',
+  facilitateur: 'facilitator',
+  admin: 'facilitator',
+};
+
+function normalizeRole(role) {
+  if (!role) return 'student';
+  return roleAliases[String(role).trim().toLowerCase()] ?? 'student';
+}
+
 export async function getSession() {
   if (!supabase) return null;
   const { data } = await supabase.auth.getSession();
@@ -27,15 +43,67 @@ export async function signOut() {
   await supabase.auth.signOut();
 }
 
-export async function getCurrentRole() {
+export async function getCurrentUserProfile() {
   const session = await getSession();
-  if (!session || !supabase) return 'student';
+  if (!session || !supabase) return { data: null, error: null };
 
-  const { data } = await supabase
+  return supabase
     .from('profiles')
-    .select('role')
+    .select('id, role, organization_id')
     .eq('id', session.user.id)
     .maybeSingle();
+}
 
-  return data?.role ?? 'student';
+export async function getCurrentUserMembership() {
+  const session = await getSession();
+  if (!session || !supabase) return { data: null, error: null };
+
+  return supabase
+    .from('memberships')
+    .select('role, organization_id, created_at')
+    .eq('user_id', session.user.id)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+}
+
+export async function getCurrentUserContext() {
+  const session = await getSession();
+  if (!session || !supabase) {
+    return {
+      session,
+      role: 'student',
+      organizationId: null,
+      profile: null,
+      membership: null,
+      errors: [],
+    };
+  }
+
+  const [profileResult, membershipResult] = await Promise.all([
+    getCurrentUserProfile(),
+    getCurrentUserMembership(),
+  ]);
+
+  const role = normalizeRole(membershipResult.data?.role ?? profileResult.data?.role);
+  const organizationId = membershipResult.data?.organization_id ?? profileResult.data?.organization_id ?? null;
+
+  return {
+    session,
+    role,
+    organizationId,
+    profile: profileResult.data,
+    membership: membershipResult.data,
+    errors: [profileResult.error, membershipResult.error].filter(Boolean),
+  };
+}
+
+export async function getCurrentRole() {
+  const context = await getCurrentUserContext();
+  return context.role;
+}
+
+export async function getCurrentUserOrganizationId() {
+  const context = await getCurrentUserContext();
+  return context.organizationId;
 }

--- a/web/src/guards.js
+++ b/web/src/guards.js
@@ -1,23 +1,27 @@
-import { getSession, getCurrentRole } from './auth.js';
+import { getCurrentRole, getSession } from './auth.js';
 
-export async function requireSession() {
+function redirectTo(pathname) {
+  window.history.pushState({}, '', pathname);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
+export async function requireSession(redirectPath = '/login') {
   const session = await getSession();
   if (!session) {
-    window.history.pushState({}, '', '/login');
-    window.dispatchEvent(new PopStateEvent('popstate'));
+    redirectTo(redirectPath);
     return null;
   }
   return session;
 }
 
-export async function requireRole(allowedRoles) {
+export async function requireRole(allowedRoles, options = {}) {
+  const { redirectPath = '/dashboard' } = options;
   const session = await requireSession();
   if (!session) return null;
 
   const role = await getCurrentRole();
   if (!allowedRoles.includes(role)) {
-    window.history.pushState({}, '', '/dashboard');
-    window.dispatchEvent(new PopStateEvent('popstate'));
+    redirectTo(redirectPath);
     return null;
   }
 

--- a/web/src/routes.js
+++ b/web/src/routes.js
@@ -1,5 +1,12 @@
-import { getCurrentRole, getSession, signInWithMagicLink, signInWithPassword, signOut } from './auth.js';
+import {
+  getCurrentUserContext,
+  getSession,
+  signInWithMagicLink,
+  signInWithPassword,
+  signOut,
+} from './auth.js';
 import { requireRole, requireSession } from './guards.js';
+import { supabase } from './supabase.js';
 
 const studentActions = [
   'I observed something',
@@ -8,26 +15,57 @@ const studentActions = [
   'What we learned',
 ];
 
-function shell(content) {
+function getMenuItemsByRole(role) {
+  if (role === 'facilitator') {
+    return [
+      { href: '/', label: 'Maison' },
+      { href: '/dashboard', label: 'Tableau de bord' },
+      { href: '/lycees', label: 'Lycées' },
+      { href: '/admin', label: 'Administrateur' },
+      { href: '/publication', label: 'Publication' },
+    ];
+  }
+
+  if (role === 'referent') {
+    return [
+      { href: '/', label: 'Maison' },
+      { href: '/dashboard', label: 'Tableau de bord' },
+      { href: '/mon-lycee', label: 'Mon lycée' },
+      { href: '/contributions', label: 'Contributions établissement' },
+    ];
+  }
+
+  return [
+    { href: '/', label: 'Maison' },
+    { href: '/dashboard', label: 'Tableau de bord' },
+    { href: '/mon-lycee', label: 'Mon lycée' },
+    { href: '/contributions', label: 'Mes contributions' },
+  ];
+}
+
+async function shell(content) {
+  const session = await getSession();
+  const context = session ? await getCurrentUserContext() : { role: null };
+
+  const items = session
+    ? getMenuItemsByRole(context.role)
+    : [{ href: '/', label: 'Maison' }, { href: '/login', label: 'Connexion' }];
+
   return `
     <nav>
       <div class="links container">
-        <a class="btn" href="/">Home</a>
-        <a class="btn" href="/dashboard">Dashboard</a>
-        <a class="btn" href="/lycees">Lycées</a>
-        <a class="btn" href="/admin">Admin</a>
-        <a class="btn" href="/publications/demo">Publication</a>
+        ${items.map((item) => `<a class="btn" href="${item.href}">${item.label}</a>`).join('')}
       </div>
     </nav>
     <main class="container">${content}</main>
   `;
 }
 
-function notFound() {
+async function notFound() {
   return shell(`
     <section class="card">
-      <h1 class="h1">Page not found</h1>
-      <a class="btn" href="/">Return home</a>
+      <h1 class="h1">Page non trouvée</h1>
+      <a class="btn" href="/">Retour à la maison</a>
     </section>
   `);
 }
@@ -35,11 +73,11 @@ function notFound() {
 async function home() {
   return shell(`
     <section class="card">
-      <h1 class="h1">Transition Lab V0.3.1</h1>
-      <p class="muted">Private-by-default prototype for 4 pilot high schools.</p>
-      <div class="notice">Public visibility is only allowed after explicit Äerdschëff validation.</div>
+      <h1 class="h1">Transition Lab V0.3.2</h1>
+      <p class="muted">Prototype private-by-default pour les lycées pilotes.</p>
+      <div class="notice">La visibilité publique est autorisée seulement après validation explicite Äerdschëff.</div>
       <div style="margin-top:.75rem">
-        <a class="btn primary" href="/login">Invitation login</a>
+        <a class="btn primary" href="/login">Connexion invitation</a>
       </div>
     </section>
   `);
@@ -48,13 +86,13 @@ async function home() {
 async function login() {
   return shell(`
     <section class="card">
-      <h1 class="h1">Invitation-based login</h1>
-      <p class="muted">No open registration. Enter invited email to receive a secure sign-in link.</p>
-      <p class="notice">Requires VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in your local environment.</p>
+      <h1 class="h1">Connexion par invitation</h1>
+      <p class="muted">Pas d'inscription ouverte. Entrez l'email invité pour recevoir un lien de connexion sécurisé.</p>
+      <p class="notice">Nécessite VITE_SUPABASE_URL et VITE_SUPABASE_ANON_KEY dans votre environnement local.</p>
       <form id="login-form" class="grid" style="margin-top:.75rem">
         <input required type="email" name="email" placeholder="invited.user@school.lu" />
-        <input type="password" name="password" placeholder="Password (test accounts only)" />
-        <button class="btn primary" type="submit">Send magic link</button>
+        <input type="password" name="password" placeholder="Mot de passe (comptes de test)" />
+        <button class="btn primary" type="submit">Envoyer le magic link</button>
         <button class="btn" type="button" id="password-login-btn">Connexion test avec mot de passe</button>
       </form>
     </section>
@@ -64,107 +102,209 @@ async function login() {
 async function dashboard() {
   const session = await requireSession();
   if (!session) return '';
-  const role = await getCurrentRole();
+
+  const context = await getCurrentUserContext();
 
   return shell(`
     <section class="card">
-      <h1 class="h1">Dashboard</h1>
-      <p class="muted">Role: <span class="badge">${role}</span></p>
-      ${role === 'student' ? `
-        <h2 class="h2">Your 4 actions</h2>
+      <h1 class="h1">Tableau de bord</h1>
+      <p class="muted">Rôle: <span class="badge">${context.role}</span></p>
+      ${context.role === 'student' ? `
+        <h2 class="h2">Vos 4 actions</h2>
         <ul class="clean">
           ${studentActions.map((action) => `<li><button class="btn" type="button">${action}</button></li>`).join('')}
         </ul>
       ` : `
-        <h2 class="h2">Pilot overview</h2>
-        <p class="muted">Review project submissions and move statuses toward validation.</p>
+        <h2 class="h2">Vue d'ensemble</h2>
+        <p class="muted">Suivez les contributions de votre périmètre et leur validation.</p>
       `}
-      <div style="margin-top:1rem"><button id="logout" class="btn">Sign out</button></div>
+      <div style="margin-top:1rem"><button id="logout" class="btn">Déconnexion</button></div>
     </section>
   `);
 }
 
+async function fetchOrganizationsForContext(context) {
+  if (!supabase) return { organizations: [], error: new Error('Supabase not configured') };
+
+  if (context.role === 'facilitator') {
+    const { data, error } = await supabase.from('organizations').select('id, name').order('name');
+    return { organizations: data ?? [], error };
+  }
+
+  if (!context.organizationId) {
+    return { organizations: [], error: null };
+  }
+
+  const { data, error } = await supabase
+    .from('organizations')
+    .select('id, name')
+    .eq('id', context.organizationId)
+    .limit(1);
+
+  return { organizations: data ?? [], error };
+}
+
+async function fetchProjectsForContext(context) {
+  if (!supabase) return { projects: [], error: new Error('Supabase not configured') };
+
+  let query = supabase.from('projects').select('id, title, status, organization_id').order('created_at', { ascending: false });
+
+  if (context.role !== 'facilitator' && context.organizationId) {
+    query = query.eq('organization_id', context.organizationId);
+  }
+
+  const { data, error } = await query.limit(50);
+  return { projects: data ?? [], error };
+}
+
 async function lycees() {
-  await requireSession();
+  const guard = await requireRole(['facilitator'], { redirectPath: '/mon-lycee' });
+  if (!guard) return '';
+
+  const context = await getCurrentUserContext();
+  const { organizations, error } = await fetchOrganizationsForContext(context);
+
   return shell(`
     <section class="card">
-      <h1 class="h1">Pilot high schools</h1>
+      <h1 class="h1">Lycées</h1>
+      ${error ? `<p class="notice">Erreur de lecture organizations: ${error.message}</p>` : ''}
       <ul>
-        <li>Lycée Pilote Nord</li>
-        <li>Lycée Pilote Sud</li>
-        <li>Lycée Pilote Est</li>
-        <li>Lycée Pilote Ouest</li>
+        ${organizations.map((org) => `<li>${org.name}</li>`).join('') || '<li>Aucun lycée trouvé.</li>'}
+      </ul>
+    </section>
+  `);
+}
+
+async function monLycee() {
+  const session = await requireSession();
+  if (!session) return '';
+
+  const context = await getCurrentUserContext();
+  const { organizations, error: orgError } = await fetchOrganizationsForContext(context);
+  const { projects, error: projectError } = await fetchProjectsForContext(context);
+
+  return shell(`
+    <section class="card">
+      <h1 class="h1">Mon lycée</h1>
+      ${(orgError || projectError) ? `<p class="notice">Certaines données sont bloquées (RLS ou schéma): ${(orgError || projectError).message}</p>` : ''}
+      <h2 class="h2">Établissement</h2>
+      <ul>
+        ${organizations.map((org) => `<li>${org.name}</li>`).join('') || '<li>Aucun établissement associé.</li>'}
+      </ul>
+      <h2 class="h2">Projets de l’établissement</h2>
+      <ul>
+        ${projects.map((project) => `<li>${project.title ?? `Projet ${project.id}`} · ${project.status ?? 'draft'}</li>`).join('') || '<li>Aucun projet disponible.</li>'}
+      </ul>
+    </section>
+  `);
+}
+
+async function contributions() {
+  const session = await requireSession();
+  if (!session) return '';
+
+  const context = await getCurrentUserContext();
+  const { projects, error } = await fetchProjectsForContext(context);
+  const title = context.role === 'referent' ? 'Contributions établissement' : 'Mes contributions';
+
+  return shell(`
+    <section class="card">
+      <h1 class="h1">${title}</h1>
+      ${error ? `<p class="notice">Erreur de lecture projects: ${error.message}</p>` : ''}
+      <ul>
+        ${projects.map((project) => `<li>${project.title ?? `Projet ${project.id}`} · ${project.status ?? 'draft'}</li>`).join('') || '<li>Aucune contribution disponible.</li>'}
       </ul>
     </section>
   `);
 }
 
 async function project(pathname) {
-  await requireSession();
+  const session = await requireSession();
+  if (!session) return '';
+
   const id = pathname.split('/')[2];
   return shell(`
     <section class="card">
-      <h1 class="h1">Project ${id}</h1>
-      <p class="muted">Default status: draft. Content remains private until publication status is reached.</p>
+      <h1 class="h1">Projet ${id}</h1>
+      <p class="muted">Contenu privé par défaut jusqu’à validation publication.</p>
       <div class="grid grid-2">
-        <a class="btn" href="/projects/${id}/journal">Open journal</a>
-        <a class="btn" href="/projects/${id}/ideas">Open ideas</a>
+        <a class="btn" href="/projects/${id}/journal">Journal</a>
+        <a class="btn" href="/projects/${id}/ideas">Idées</a>
       </div>
     </section>
   `);
 }
 
 async function journal(pathname) {
-  await requireSession();
+  const session = await requireSession();
+  if (!session) return '';
+
   const id = pathname.split('/')[2];
   return shell(`
     <section class="card">
-      <h1 class="h1">Project ${id} · Journal</h1>
-      <p class="muted">Capture observations, tests, and learning notes.</p>
-      <textarea rows="5" placeholder="Placeholder journal input"></textarea>
-      <div style="margin-top:.75rem"><button class="btn primary">Save draft</button></div>
+      <h1 class="h1">Projet ${id} · Journal</h1>
+      <p class="muted">Capture observations, tests et apprentissages.</p>
+      <textarea rows="5" placeholder="Saisie journal"></textarea>
+      <div style="margin-top:.75rem"><button class="btn primary">Enregistrer brouillon</button></div>
     </section>
   `);
 }
 
 async function ideas(pathname) {
-  await requireSession();
+  const session = await requireSession();
+  if (!session) return '';
+
   const id = pathname.split('/')[2];
   return shell(`
     <section class="card">
-      <h1 class="h1">Project ${id} · Ideas</h1>
-      <p class="muted">Track idea discussions and decision state.</p>
+      <h1 class="h1">Projet ${id} · Idées</h1>
+      <p class="muted">Suivi des décisions d'idées.</p>
       <select>
         <option>pending</option><option>test</option><option>modify</option><option>abandon</option><option>escalated</option><option>published_summary</option>
       </select>
-      <div style="margin-top:.75rem"><button class="btn primary">Update decision</button></div>
+      <div style="margin-top:.75rem"><button class="btn primary">Mettre à jour</button></div>
     </section>
   `);
 }
 
 async function admin() {
-  const guard = await requireRole(['admin', 'facilitator']);
+  const guard = await requireRole(['facilitator']);
   if (!guard) return '';
 
   return shell(`
     <section class="card">
-      <h1 class="h1">Validation console</h1>
-      <p class="muted">Only facilitator/admin can validate content for publication.</p>
+      <h1 class="h1">Console de validation</h1>
+      <p class="muted">Seul le facilitateur peut valider du contenu pour publication.</p>
       <div class="grid">
-        <button class="btn">Mark as validated_local</button>
-        <button class="btn primary">Mark as validated_global</button>
-        <button class="btn">Publish reviewed content</button>
+        <button class="btn">Marquer validated_local</button>
+        <button class="btn primary">Marquer validated_global</button>
+        <button class="btn">Publier le contenu validé</button>
       </div>
     </section>
   `);
 }
 
-async function publication(pathname) {
+async function publication() {
+  const guard = await requireRole(['facilitator']);
+  if (!guard) return '';
+
+  return shell(`
+    <section class="card">
+      <h1 class="h1">Publication</h1>
+      <p class="muted">Page de publication interne. Expose uniquement les éléments publiés.</p>
+    </section>
+  `);
+}
+
+async function publicationBySlug(pathname) {
+  const session = await requireSession();
+  if (!session) return '';
+
   const slug = pathname.split('/')[2];
   return shell(`
     <section class="card">
       <h1 class="h1">Publication: ${slug}</h1>
-      <p class="muted">Public page placeholder. Should only expose items with status published.</p>
+      <p class="muted">Aperçu publication (accès session requis).</p>
     </section>
   `);
 }
@@ -174,11 +314,14 @@ export async function renderRoute(pathname) {
   if (pathname === '/login') return login();
   if (pathname === '/dashboard') return dashboard();
   if (pathname === '/lycees') return lycees();
+  if (pathname === '/mon-lycee') return monLycee();
+  if (pathname === '/contributions') return contributions();
   if (pathname === '/admin') return admin();
+  if (pathname === '/publication') return publication();
   if (/^\/projects\/[^/]+$/.test(pathname)) return project(pathname);
   if (/^\/projects\/[^/]+\/journal$/.test(pathname)) return journal(pathname);
   if (/^\/projects\/[^/]+\/ideas$/.test(pathname)) return ideas(pathname);
-  if (/^\/publications\/[^/]+$/.test(pathname)) return publication(pathname);
+  if (/^\/publications\/[^/]+$/.test(pathname)) return publicationBySlug(pathname);
   return notFound();
 }
 


### PR DESCRIPTION
…outes

### Motivation
- Support role- and organization-scoped access across the app and database to implement V0.3.2 role-based scoping and RLS constraints.
- Provide a consistent user context (role + organization) derived from `profiles` and `memberships` to drive UI and query scoping.
- Expose suggested RLS policies for `organizations`, `projects`, and `memberships` to enforce privacy by default.
- Localize UI copy to French and simplify navigation based on user roles (facilitator / referent / student).

### Description
- Add `web/docs/rls-v0.3.2-notes.sql` with suggested Row Level Security policies for `organizations`, `projects`, and `memberships` to limit reads to facilitators/admins or scoped organization members.
- Replace and extend auth logic in `web/src/auth.js` by adding `roleAliases`, `normalizeRole`, and new functions `getCurrentUserProfile`, `getCurrentUserMembership`, `getCurrentUserContext`, and `getCurrentUserOrganizationId`, while keeping `getCurrentRole` wired to the unified context.
- Update guards in `web/src/guards.js` to use a `redirectTo` helper and make `requireSession`/`requireRole` accept configurable redirect paths.
- Overhaul `web/src/routes.js` to use `getCurrentUserContext`, render role-specific menu items via `getMenuItemsByRole`, add data fetch helpers `fetchOrganizationsForContext` and `fetchProjectsForContext` that scope queries by `organization_id` unless the user is a facilitator, add and wire new routes (`/mon-lycee`, `/contributions`, `/publication`), and translate UI copy to French; tighten admin access to facilitator-only where applicable.
- Import `supabase` into routes and ensure pages handle missing sessions and RLS query errors with user-facing notices.

### Testing
- No automated tests were added or executed as part of this change.